### PR TITLE
Logged in multiple addresses bug and null check added for response from eligibility call

### DIFF
--- a/toshi/Shipping/Model/Carrier/Shipping.php
+++ b/toshi/Shipping/Model/Carrier/Shipping.php
@@ -108,7 +108,11 @@ class Shipping extends AbstractCarrier implements CarrierInterface
       curl_setopt($request, CURLOPT_POSTFIELDS, $json);
       curl_setopt($request, CURLOPT_HTTPHEADER, array("X-Toshi-Server-Api-Key: {$toshiApiKey}", "Content-Type: application/json"));
 
-      $response =  json_decode(curl_exec($request));
+      $response = json_decode(curl_exec($request));
+
+      if ($response === NULL) {
+        return false;
+      }
 
       if (array_key_exists("eligible", $response)) {
           return $response->eligible;

--- a/toshi/Shipping/view/frontend/web/js/toshi.js
+++ b/toshi/Shipping/view/frontend/web/js/toshi.js
@@ -53,23 +53,9 @@ function launchToshi() {
 
     // Logged in customer with existing address
     if (isCustomerLoggedIn && customerData.addresses.length > 0) {
-      var addressIndex = jQuery(".shipping-address-items").children(".selected-item").index();
-
-      modal.setFirstName(customerData.addresses[addressIndex].firstname);
-      modal.setLastName(customerData.addresses[addressIndex].lastname);
-      modal.setEmail(getCustomerEmail());
-      modal.setPhone(customerData.addresses[addressIndex].telephone);
-      modal.setAddress({
-        addressLine1: customerData.addresses[addressIndex].street[0],
-        addressLine2: customerData.addresses[addressIndex].street[1],
-        town: customerData.addresses[addressIndex].city,
-        province: customerData.addresses[addressIndex].region.region,
-        postcode: customerData.addresses[addressIndex].postcode,
-        country: customerData.addresses[addressIndex].country_id
-      });
-
+      setDetailsFromCustomerData();
     } else { // Logged in customer with no existing address or guest customer
-      addressFields = ['input[name=street\\[0\\]]', 'input[name=street\\[1\\]]', 'input[name=city]', 'input[name=region]', 'input[name=postcode]'];
+      addressFields = ['input[name=street\\[0\\]]', 'input[name=street\\[1\\]]', 'input[name=city]', 'input[name=region]', 'input[name=postcode]', 'input[name=country_id]'];
       modal.setFirstName(jQuery('input[name=firstname]').val());
       modal.setLastName(jQuery('input[name=lastname]').val());
       modal.setEmail(getCustomerEmail());
@@ -173,6 +159,49 @@ function getCustomerEmail() {
   }
 }
 
+function setDetailsFromCustomerData() {
+  var addressIndex = jQuery(".shipping-address-items").children(".selected-item").index();
+  var cacheStorage = localStorage.getItem('mage-cache-storage');
+
+  // New address added not yet present in customerData
+  if ((addressIndex + 1) > jQuery(".shipping-address-items").length) {
+
+    if (cacheStorage == null) {
+      return false;
+    }
+    
+    var newAddress = JSON.parse(cacheStorage)['checkout-data'].newCustomerShippingAddress
+
+    modal.setFirstName(newAddress.firstname);
+    modal.setLastName(newAddress.lastname);
+    modal.setEmail(getCustomerEmail());
+    modal.setPhone(newAddress.telephone);
+    modal.setAddress({
+      addressLine1: newAddress.street[0],
+      addressLine2: newAddress.street[1],
+      town: newAddress.city,
+      province: newAddress.region,
+      postcode: newAddress.postcode,
+      country: newAddress.country_id
+    });
+
+  // Get the selected address details from customerData
+  } else {
+    modal.setFirstName(customerData.addresses[addressIndex].firstname);
+    modal.setLastName(customerData.addresses[addressIndex].lastname);
+    modal.setEmail(getCustomerEmail());
+    modal.setPhone(customerData.addresses[addressIndex].telephone);
+    modal.setAddress({
+      addressLine1: customerData.addresses[addressIndex].street[0],
+      addressLine2: customerData.addresses[addressIndex].street[1],
+      town: customerData.addresses[addressIndex].city,
+      province: customerData.addresses[addressIndex].region.region,
+      postcode: customerData.addresses[addressIndex].postcode,
+      country: customerData.addresses[addressIndex].country_id
+    });
+  }
+}
+
 // Get container
 const getContainerElement = () =>
 document.getElementById(
@@ -188,6 +217,10 @@ var obs = new MutationObserver(function(mutations, observer) {
   if (getContainerElement() && typeof modal != 'undefined' && jQuery('#toshi-app').length === 0){
     jQuery('#label_carrier_toshi_toshi').append('<div id="toshi-app"></div>');
     modal.mount(document.getElementById('toshi-app'));
+  }
+
+  if (toshiLaunched && isCustomerLoggedIn && customerData.addresses.length > 0) {
+    setDetailsFromCustomerData();
   }
 });
 

--- a/toshi/Shipping/view/frontend/web/js/toshi.js
+++ b/toshi/Shipping/view/frontend/web/js/toshi.js
@@ -161,6 +161,12 @@ function getCustomerEmail() {
 
 function setDetailsFromCustomerData() {
   var addressIndex = jQuery(".shipping-address-items").children(".selected-item").index();
+
+  // Switching between addresses and none selected at this stage
+  if (addressIndex < 0) {
+    return false;
+  }
+
   var cacheStorage = localStorage.getItem('mage-cache-storage');
 
   // New address added not yet present in customerData


### PR DESCRIPTION
Functionality added to correctly update modal properties when switching between or adding addresses on checkout page while logged in as customer. 

Also added null check for response from the eligibility call.